### PR TITLE
made compatible with np.ndarray

### DIFF
--- a/vMF/vMF.py
+++ b/vMF/vMF.py
@@ -15,46 +15,70 @@ import numpy as np
 
 __all__ = ['sample_vMF']
 
-
-def sample_vMF(mu, kappa, num_samples):
-    """Generate num_samples N-dimensional samples from von Mises Fisher
+def sample_vMF(mu, kappa, num_samples=1):
+    """Generate N-dimensional samples from von Mises Fisher
     distribution around center mu \in R^N with concentration kappa.
+    mu and kappa may be vectors,
+    mu should have shape (dim, N), kappa should be vector of length N.
+    num_samples is only used if mu is of shape (3, 1) and kappa is scalar.
     """
-    dim = len(mu)
-    result = np.zeros((num_samples, dim))
-    for nn in range(num_samples):
-        # sample offset from center (on sphere) with spread kappa
-        w = _sample_weight(kappa, dim)
 
-        # sample a point v on the unit sphere that's orthogonal to mu
-        v = _sample_orthonormal_to(mu)
+    if isinstance(kappa, np.ndarray):
+        dim = mu.shape[0]
+        assert mu.shape[1] == kappa.size
+    else:
+        dim = mu.size
+        mu = np.vstack(num_samples*(mu,)).T
+        kappa = np.full(num_samples, kappa)
 
-        # compute new point
-        result[nn, :] = v * np.sqrt(1. - w**2) + w * mu
+    # sample offset from center (on sphere) with spread kappa
+    w = _sample_weight(kappa, dim)
 
-    return result
+    # sample a point v on the unit sphere that's orthogonal to mu
+    v = _sample_orthonormal_to(mu)
 
+    # compute new point
+    result = v * np.sqrt(1. - w**2) + w * mu
+    #returns result.T to be backwards compatible
+    return result.T
 
 def _sample_weight(kappa, dim):
     """Rejection sampling scheme for sampling distance from center on
     surface of the sphere.
     """
     dim = dim - 1  # since S^{n-1}
+    try:
+        size = kappa.size
+    except AttributeError:
+        size = 1
     b = dim / (np.sqrt(4. * kappa**2 + dim**2) + 2 * kappa)
     x = (1. - b) / (1. + b)
     c = kappa * x + dim * np.log(1 - x**2)
-
+    w = np.zeros(size)
+    idx = np.zeros(size, dtype=int)
     while True:
-        z = np.random.beta(dim / 2., dim / 2.)
-        w = (1. - (1. + b) * z) / (1. - (1. - b) * z)
-        u = np.random.uniform(low=0, high=1)
-        if kappa * w + dim * np.log(1. - x * w) - c >= np.log(u):
+        #TODO make more efficient
+        #samples for every kappa and only uses the according sample
+        #only if it is still needed, else discarded
+        where_zero = np.nonzero(idx == 0)
+        done = np.all(idx)
+        if done:
             return w
-
+        z = np.random.beta(dim / 2., dim / 2., size=size)
+        _w = (1. - (1. + b) * z) / (1. - (1. - b) * z)
+        u = np.random.uniform(low=0, high=1, size=size)
+        _idx = np.nonzero(kappa * _w + dim * np.log(1. - x * _w) - c >= np.log(u))
+        if _idx[0].size == 0:
+            continue
+        else:
+            #sort into correct slots of w
+            w[where_zero] = _w[where_zero]
+            idx[_idx] = 1
 
 def _sample_orthonormal_to(mu):
     """Sample point on sphere orthogonal to mu."""
-    v = np.random.randn(mu.shape[0])
-    proj_mu_v = mu * np.dot(mu, v) / np.linalg.norm(mu)
-    orthto = v - proj_mu_v
-    return orthto / np.linalg.norm(orthto)
+    v = np.random.randn(*reversed(mu.shape))
+    proj_mu_v =  mu * np.diag(np.matmul(v, mu)) / np.linalg.norm(mu, axis=0)
+    orthto = v - proj_mu_v.T
+    return orthto.T / np.linalg.norm(orthto.T, axis=0)
+


### PR DESCRIPTION
vMF made compatible with array-like arguments, i.e. multiple directions with different kappa can be sampled by a single call.